### PR TITLE
Bmp stack uart fixes

### DIFF
--- a/components/blackmagic/general.h
+++ b/components/blackmagic/general.h
@@ -1,8 +1,9 @@
 #undef _GNU_SOURCE
 #include_next <general.h>
 
-#ifndef TEST
-#define TEST
+#ifndef __BLACKMAGIC_GENERAL_H__
+#define __BLACKMAGIC_GENERAL_H__
+
 #include <string.h>
 #undef DEBUG_WARN
 #undef DEBUG_INFO
@@ -90,4 +91,9 @@
 #define DEBUG_GDB(x, ...)
 #define DEBUG_TARGET(x, ...)
 #endif
-#endif
+
+/* Use bit-banged GPIO to drive SWD */
+#define SWDPTAP_MODE_GPIO 1
+#define SWDPTAP_MODE_ULP 0
+
+#endif /* __BLACKMAGIC_GENERAL_H__ */

--- a/components/blackmagic/jtagtap.c
+++ b/components/blackmagic/jtagtap.c
@@ -40,13 +40,15 @@ int jtagtap_init(void)
 	gpio_reset_pin(CONFIG_TDO_GPIO);
 	gpio_reset_pin(CONFIG_TMS_SWDIO_GPIO);
 	gpio_reset_pin(CONFIG_TCK_SWCLK_GPIO);
-	gpio_reset_pin(CONFIG_TMS_SWDIO_DIR_GPIO);
+	if (CONFIG_TMS_SWDIO_DIR_GPIO >= 0)
+		gpio_reset_pin(CONFIG_TMS_SWDIO_DIR_GPIO);
 
 	gpio_set_direction(CONFIG_TDI_GPIO, GPIO_MODE_OUTPUT);
 	gpio_set_direction(CONFIG_TDO_GPIO, GPIO_MODE_INPUT);
 	gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, GPIO_MODE_OUTPUT);
 	gpio_set_direction(CONFIG_TCK_SWCLK_GPIO, GPIO_MODE_OUTPUT);
-	gpio_set_direction(CONFIG_TMS_SWDIO_DIR_GPIO, GPIO_MODE_OUTPUT);
+	if (CONFIG_TMS_SWDIO_DIR_GPIO >= 0)
+		gpio_set_direction(CONFIG_TMS_SWDIO_DIR_GPIO, GPIO_MODE_OUTPUT);
 
 	TMS_SET_MODE();
 

--- a/components/blackmagic/swdptap-gpio.c
+++ b/components/blackmagic/swdptap-gpio.c
@@ -1,5 +1,3 @@
-#include "sdkconfig.h"
-#if CONFIG_IDF_TARGET_ESP32
 /*
  * This file is part of the Black Magic Debug project.
  *
@@ -29,6 +27,8 @@
 #include "timing.h"
 #include "adiv5.h"
 
+#if SWDPTAP_MODE_GPIO == 1
+
 uint32_t swd_delay_cnt = 0;
 
 enum {
@@ -41,10 +41,109 @@ static IRAM_ATTR bool swdptap_seq_in_parity(uint32_t *ret, size_t ticks) __attri
 static IRAM_ATTR void swdptap_seq_out(uint32_t MS, size_t ticks) __attribute__((optimize(3)));
 static IRAM_ATTR void swdptap_seq_out_parity(uint32_t MS, size_t ticks) __attribute__((optimize(3)));
 
+static inline void swdio_high(void)
+{
+#if SWDIO_PIN < 32
+	GPIO.out_w1ts = (1 << SWDIO_PIN);
+#else
+	GPIO.out1_w1ts.data = (1 << (SWDIO_PIN - 32));
+#endif
+}
+
+static inline void swdio_low(void)
+{
+#if SWDIO_PIN < 32
+	GPIO.out_w1tc = (1 << SWDIO_PIN);
+#else
+	GPIO.out1_w1tc.data = (1 << (SWDIO_PIN - 32));
+#endif
+}
+
+static inline void swdio_set(uint32_t val)
+{
+	if (val) {
+		swdio_high();
+	} else {
+		swdio_low();
+	}
+}
+
+static inline uint32_t swdio_get(void)
+{
+#if SWDIO_PIN < 32
+	return GPIO.in & (1 << SWDIO_PIN);
+#else
+	return GPIO.in1.data & (1 << (SWDIO_PIN - 32));
+#endif
+}
+
+static inline void swclk_high(void)
+{
+#if SWCLK_PIN < 32
+	GPIO.out_w1ts = (1 << SWCLK_PIN);
+#else
+	GPIO.out1_w1ts.data = (1 << (SWCLK_PIN - 32));
+#endif
+}
+
+static inline void swclk_low(void)
+{
+#if SWCLK_PIN < 32
+	GPIO.out_w1tc = (1 << SWCLK_PIN);
+#else
+	GPIO.out1_w1tc.data = (1 << (SWCLK_PIN - 32));
+#endif
+}
+
+static inline void swdio_mode_float(void)
+{
+	gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, GPIO_MODE_INPUT);
+	// #if CONFIG_TMS_SWDIO_GPIO < 32
+	// 	GPIO.enable_w1tc = (0x1 << CONFIG_TMS_SWDIO_GPIO);
+	// #else
+	// 	GPIO.enable1_w1tc.data = (0x1 << (CONFIG_TMS_SWDIO_GPIO - 32));
+	// #endif
+
+#if CONFIG_TMS_SWDIO_DIR_GPIO < 0
+	// Do nothing if the DIR GPIO is -1
+#elif CONFIG_TMS_SWDIO_DIR_GPIO < 32
+	GPIO.out_w1ts = (1 << CONFIG_TMS_SWDIO_DIR_GPIO);
+#else
+	GPIO.out1_w1ts.data = (1 << (CONFIG_TMS_SWDIO_DIR_GPIO - 32));
+#endif
+}
+
+static inline void swdio_mode_drive(void)
+{
+#if CONFIG_TMS_SWDIO_DIR_GPIO < 0
+	// Do nothing if the DIR GPIO is -1
+#elif CONFIG_TMS_SWDIO_DIR_GPIO < 32
+	GPIO.out_w1tc = (1 << CONFIG_TMS_SWDIO_DIR_GPIO);
+#else
+	GPIO.out1_w1tc.data = (1 << (CONFIG_TMS_SWDIO_DIR_GPIO - 32));
+#endif
+
+	// #if CONFIG_TMS_SWDIO_GPIO < 32
+	// 	GPIO.enable_w1ts = (0x1 << CONFIG_TMS_SWDIO_GPIO);
+	// #else
+	// 	GPIO.enable1_w1ts.data = (0x1 << (CONFIG_TMS_SWDIO_GPIO - 32));
+	// #endif
+	gpio_ll_output_enable(GPIO_HAL_GET_HW(GPIO_PORT_0), CONFIG_TMS_SWDIO_GPIO);
+}
+
 static void swdptap_turnaround(int dir)
 {
 	static int olddir = SWDIO_STATUS_FLOAT;
 	register volatile int32_t cnt;
+
+	// Throw in a sleep every now and then, in order to allow
+	// for other tasks to run.
+	static int rest_counter = 0;
+	rest_counter += 1;
+	if (rest_counter > 1000) {
+		rest_counter = 0;
+		vTaskDelay(1);
+	}
 
 	/* Don't turnaround if direction not changing */
 	if (dir == olddir)
@@ -55,15 +154,15 @@ static void swdptap_turnaround(int dir)
 	DEBUG("%s", dir ? "\n-> " : "\n<- ");
 #endif
 	if (dir == SWDIO_STATUS_FLOAT)
-		SWDIO_MODE_FLOAT();
-	gpio_set(SWCLK_PORT, SWCLK_PIN);
+		swdio_mode_float();
+	swclk_high();
 	for (cnt = swd_delay_cnt; --cnt > 0;)
 		;
-	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	swclk_low();
 	for (cnt = swd_delay_cnt; --cnt > 0;)
 		;
 	if (dir == SWDIO_STATUS_DRIVE)
-		SWDIO_MODE_DRIVE();
+		swdio_mode_drive();
 }
 
 static uint32_t swdptap_seq_in(size_t ticks)
@@ -77,31 +176,30 @@ static uint32_t swdptap_seq_in(size_t ticks)
 	if (swd_delay_cnt) {
 		while (len--) {
 			int res;
-			res = gpio_get(SWDIO_PORT, SWDIO_PIN);
-			gpio_set(SWCLK_PORT, SWCLK_PIN);
+			res = swdio_get();
+			swclk_high();
 			for (cnt = swd_delay_cnt; --cnt > 0;)
 				;
 			ret |= (res) ? index : 0;
 			index <<= 1;
-			gpio_clear(SWCLK_PORT, SWCLK_PIN);
+			swclk_low();
 			for (cnt = swd_delay_cnt; --cnt > 0;)
 				;
 		}
 	} else {
 		volatile int res;
 		while (len--) {
-			res = gpio_get(SWDIO_PORT, SWDIO_PIN);
-			gpio_set(SWCLK_PORT, SWCLK_PIN);
+			res = swdio_get();
+			swclk_high();
 			ret |= (res) ? index : 0;
 			index <<= 1;
-			gpio_clear(SWCLK_PORT, SWCLK_PIN);
+			swclk_low();
 		}
 	}
 #ifdef DEBUG_SWD_BITS
 	for (int i = 0; i < len; i++)
 		DEBUG("%d", (ret & (1 << i)) ? 1 : 0);
 #endif
-	// portEXIT_CRITICAL();
 	return ret;
 }
 
@@ -112,37 +210,36 @@ static bool swdptap_seq_in_parity(uint32_t *ret, size_t ticks)
 	bool bit;
 	int len = ticks;
 	register volatile int32_t cnt;
-	// portENTER_CRITICAL();
 
 	swdptap_turnaround(SWDIO_STATUS_FLOAT);
 	if (swd_delay_cnt) {
 		while (len--) {
-			bit = gpio_get(SWDIO_PORT, SWDIO_PIN);
-			gpio_set(SWCLK_PORT, SWCLK_PIN);
+			bit = swdio_get();
+			swclk_high();
 			for (cnt = swd_delay_cnt; --cnt > 0;)
 				;
 			res |= (bit) ? index : 0;
 			index <<= 1;
-			gpio_clear(SWCLK_PORT, SWCLK_PIN);
+			swclk_low();
 			for (cnt = swd_delay_cnt; --cnt > 0;)
 				;
 		}
 	} else {
 		while (len--) {
-			bit = gpio_get(SWDIO_PORT, SWDIO_PIN);
-			gpio_set(SWCLK_PORT, SWCLK_PIN);
+			bit = swdio_get();
+			swclk_high();
 			res |= (bit) ? index : 0;
 			index <<= 1;
-			gpio_clear(SWCLK_PORT, SWCLK_PIN);
+			swclk_low();
 		}
 	}
 	int parity = __builtin_popcount(res);
-	bit = gpio_get(SWDIO_PORT, SWDIO_PIN);
-	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	bit = swdio_get();
+	swclk_high();
 	for (cnt = swd_delay_cnt; --cnt > 0;)
 		;
 	parity += (bit) ? 1 : 0;
-	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	swclk_low();
 	for (cnt = swd_delay_cnt; --cnt > 0;)
 		;
 #ifdef DEBUG_SWD_BITS
@@ -152,7 +249,6 @@ static bool swdptap_seq_in_parity(uint32_t *ret, size_t ticks)
 	*ret = res;
 	/* Terminate the read cycle now */
 	swdptap_turnaround(SWDIO_STATUS_DRIVE);
-	// portEXIT_CRITICAL();
 	return (parity & 1);
 }
 
@@ -165,27 +261,26 @@ static void swdptap_seq_out(uint32_t MS, size_t ticks)
 	// portENTER_CRITICAL();
 	register volatile int32_t cnt;
 	swdptap_turnaround(SWDIO_STATUS_DRIVE);
-	gpio_set_val(SWDIO_PORT, SWDIO_PIN, MS & 1);
+	swdio_set(MS & 1);
 	if (swd_delay_cnt) {
 		while (ticks--) {
-			gpio_set(SWCLK_PORT, SWCLK_PIN);
+			swclk_high();
 			for (cnt = swd_delay_cnt; --cnt > 0;)
 				;
 			MS >>= 1;
-			gpio_set_val(SWDIO_PORT, SWDIO_PIN, MS & 1);
-			gpio_clear(SWCLK_PORT, SWCLK_PIN);
+			swdio_set(MS & 1);
+			swclk_low();
 			for (cnt = swd_delay_cnt; --cnt > 0;)
 				;
 		}
 	} else {
 		while (ticks--) {
-			gpio_set(SWCLK_PORT, SWCLK_PIN);
+			swclk_high();
 			MS >>= 1;
-			gpio_set_val(SWDIO_PORT, SWDIO_PIN, MS & 1);
-			gpio_clear(SWCLK_PORT, SWCLK_PIN);
+			swdio_set(MS & 1);
+			swclk_low();
 		}
 	}
-	// portEXIT_CRITICAL();
 }
 
 static void swdptap_seq_out_parity(uint32_t MS, size_t ticks)
@@ -195,38 +290,36 @@ static void swdptap_seq_out_parity(uint32_t MS, size_t ticks)
 	for (int i = 0; i < ticks; i++)
 		DEBUG("%d", (MS & (1 << i)) ? 1 : 0);
 #endif
-	// portENTER_CRITICAL();
 	register volatile int32_t cnt;
 	swdptap_turnaround(SWDIO_STATUS_DRIVE);
-	gpio_set_val(SWDIO_PORT, SWDIO_PIN, MS & 1);
+	swdio_set(MS & 1);
 	MS >>= 1;
 	if (swd_delay_cnt) {
 		while (ticks--) {
-			gpio_set(SWCLK_PORT, SWCLK_PIN);
+			swclk_high();
 			for (cnt = swd_delay_cnt; --cnt > 0;)
 				;
-			gpio_set_val(SWDIO_PORT, SWDIO_PIN, MS & 1);
+			swdio_set(MS & 1);
 			MS >>= 1;
-			gpio_clear(SWCLK_PORT, SWCLK_PIN);
+			swclk_low();
 			for (cnt = swd_delay_cnt; --cnt > 0;)
 				;
 		}
 	} else {
 		while (ticks--) {
-			gpio_set(SWCLK_PORT, SWCLK_PIN);
-			gpio_set_val(SWDIO_PORT, SWDIO_PIN, MS & 1);
+			swclk_high();
+			swdio_set(MS & 1);
 			MS >>= 1;
-			gpio_clear(SWCLK_PORT, SWCLK_PIN);
+			swclk_low();
 		}
 	}
 	gpio_set_val(SWDIO_PORT, SWDIO_PIN, parity & 1);
-	gpio_set(SWCLK_PORT, SWCLK_PIN);
+	swclk_high();
 	for (cnt = swd_delay_cnt; --cnt > 0;)
 		;
-	gpio_clear(SWCLK_PORT, SWCLK_PIN);
+	swclk_low();
 	for (cnt = swd_delay_cnt; --cnt > 0;)
 		;
-	// portEXIT_CRITICAL();
 }
 
 int swdptap_init(ADIv5_DP_t *dp)
@@ -240,16 +333,18 @@ int swdptap_init(ADIv5_DP_t *dp)
 	gpio_reset_pin(CONFIG_TDO_GPIO);
 	gpio_reset_pin(CONFIG_TMS_SWDIO_GPIO);
 	gpio_reset_pin(CONFIG_TCK_SWCLK_GPIO);
+#if CONFIG_TMS_SWDIO_DIR_GPIO >= 0
 	gpio_reset_pin(CONFIG_TMS_SWDIO_DIR_GPIO);
+#endif
 
 	gpio_set_direction(CONFIG_TDI_GPIO, GPIO_MODE_OUTPUT);
 	gpio_set_direction(CONFIG_TDO_GPIO, GPIO_MODE_INPUT);
 	gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, GPIO_MODE_OUTPUT);
 	gpio_set_direction(CONFIG_TCK_SWCLK_GPIO, GPIO_MODE_OUTPUT);
+#if CONFIG_TMS_SWDIO_DIR_GPIO >= 0
 	gpio_set_direction(CONFIG_TMS_SWDIO_DIR_GPIO, GPIO_MODE_OUTPUT);
-
-	// previous_swd_dir = SWDIO_STATUS_FLOAT;
-
+	gpio_set_level(CONFIG_TMS_SWDIO_DIR_GPIO, 0);
+#endif
 	return 0;
 }
 #endif

--- a/components/blackmagic/swdptap-ulp.c
+++ b/components/blackmagic/swdptap-ulp.c
@@ -98,11 +98,11 @@ static inline void swclk_low(void)
 static inline void swdio_mode_float(void)
 {
 	gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, GPIO_MODE_INPUT);
-// #if CONFIG_TMS_SWDIO_GPIO < 32
-// 	GPIO.enable_w1tc = (0x1 << CONFIG_TMS_SWDIO_GPIO);
-// #else
-// 	GPIO.enable1_w1tc.data = (0x1 << (CONFIG_TMS_SWDIO_GPIO - 32));
-// #endif
+	// #if CONFIG_TMS_SWDIO_GPIO < 32
+	// 	GPIO.enable_w1tc = (0x1 << CONFIG_TMS_SWDIO_GPIO);
+	// #else
+	// 	GPIO.enable1_w1tc.data = (0x1 << (CONFIG_TMS_SWDIO_GPIO - 32));
+	// #endif
 
 #if CONFIG_TMS_SWDIO_DIR_GPIO < 32
 	GPIO.out_w1ts = (1 << CONFIG_TMS_SWDIO_DIR_GPIO);
@@ -119,11 +119,11 @@ static inline void swdio_mode_drive(void)
 	GPIO.out1_w1tc.data = (1 << (CONFIG_TMS_SWDIO_DIR_GPIO - 32));
 #endif
 
-// #if CONFIG_TMS_SWDIO_GPIO < 32
-// 	GPIO.enable_w1ts = (0x1 << CONFIG_TMS_SWDIO_GPIO);
-// #else
-// 	GPIO.enable1_w1ts.data = (0x1 << (CONFIG_TMS_SWDIO_GPIO - 32));
-// #endif
+	// #if CONFIG_TMS_SWDIO_GPIO < 32
+	// 	GPIO.enable_w1ts = (0x1 << CONFIG_TMS_SWDIO_GPIO);
+	// #else
+	// 	GPIO.enable1_w1ts.data = (0x1 << (CONFIG_TMS_SWDIO_GPIO - 32));
+	// #endif
 	gpio_ll_output_enable(GPIO_HAL_GET_HW(GPIO_PORT_0), CONFIG_TMS_SWDIO_GPIO);
 }
 
@@ -131,6 +131,15 @@ static void swdptap_turnaround(int dir)
 {
 	static int olddir = SWDIO_STATUS_FLOAT;
 	register volatile int32_t cnt;
+
+	// Throw in a sleep every now and then, in order to allow
+	// for other tasks to run.
+	static int rest_counter = 0;
+	rest_counter += 1;
+	if (rest_counter > 1000) {
+		rest_counter = 0;
+		vTaskDelay(1);
+	}
 
 	/* Don't turnaround if direction not changing */
 	if (dir == olddir)

--- a/components/blackmagic/swdptap-ulp.c
+++ b/components/blackmagic/swdptap-ulp.c
@@ -1,5 +1,3 @@
-#include "sdkconfig.h"
-#if CONFIG_IDF_TARGET_ESP32S3
 /*
  * This file is part of the Black Magic Debug project.
  *
@@ -26,328 +24,153 @@
 /* This file implements the SW-DP interface. */
 
 #include "general.h"
+
+#if SWDPTAP_MODE_ULP == 1
+
+/*
+ * This file is part of the Black Magic Debug project.
+ *
+ * Copyright (C) 2011  Black Sphere Technologies Ltd.
+ * Written by Gareth McMullin <gareth@blacksphere.co.nz>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* This file implements the SW-DP interface. */
+
 #include "timing.h"
 #include "adiv5.h"
+#include "driver/rtc_io.h"
+#include "esp_log.h"
+#include "ulp_riscv.h"
+#include "soc/rtc.h"
+// #include "ulp_bmp.h"
 
-uint32_t swd_delay_cnt = 0;
-
-enum {
-	SWDIO_STATUS_FLOAT = 0,
-	SWDIO_STATUS_DRIVE
-};
-static IRAM_ATTR void swdptap_turnaround(int dir) __attribute__((optimize(3)));
-static IRAM_ATTR uint32_t swdptap_seq_in(size_t ticks) __attribute__((optimize(3)));
-static IRAM_ATTR bool swdptap_seq_in_parity(uint32_t *ret, size_t ticks) __attribute__((optimize(3)));
-static IRAM_ATTR void swdptap_seq_out(uint32_t MS, size_t ticks) __attribute__((optimize(3)));
-static IRAM_ATTR void swdptap_seq_out_parity(uint32_t MS, size_t ticks) __attribute__((optimize(3)));
-
-static inline void swdio_high(void)
+extern volatile uint32_t ulp___stack_top;
+extern volatile uint32_t ulp_irq_vector;
+extern volatile uint32_t ulp_main;
+extern volatile uint32_t ulp_reset_vector;
+extern volatile uint32_t ulp_SENS;
+extern volatile uint32_t ulp_swd_direction_is_output;
+extern volatile uint32_t ulp_swd_has_parity;
+extern volatile uint32_t ulp_swd_length;
+extern volatile uint32_t ulp_swd_parity;
+extern volatile uint32_t ulp_swd_value;
+extern volatile uint32_t ulp_ulp_riscv_halt;
+extern volatile uint32_t ulp_ulp_riscv_rescue_from_monitor;
+#if 0
+static uint32_t swdptap_seq_in(size_t clock_cycles)
 {
-#if SWDIO_PIN < 32
-	GPIO.out_w1ts = (1 << SWDIO_PIN);
-#else
-	GPIO.out1_w1ts.data = (1 << (SWDIO_PIN - 32));
-#endif
+	ulp_swd_has_parity = false;
+	ulp_swd_direction_is_output = false;
+	ulp_swd_length = clock_cycles;
+	while (ulp_swd_length) {
+	}
+	return ulp_swd_value;
 }
 
-static inline void swdio_low(void)
+static bool swdptap_seq_in_parity(uint32_t *ret, size_t clock_cycles)
 {
-#if SWDIO_PIN < 32
-	GPIO.out_w1tc = (1 << SWDIO_PIN);
-#else
-	GPIO.out1_w1tc.data = (1 << (SWDIO_PIN - 32));
-#endif
+	ulp_swd_has_parity = true;
+	ulp_swd_direction_is_output = false;
+	ulp_swd_length = clock_cycles;
+	while (ulp_swd_length) {
+	}
+	*ret = ulp_swd_value;
+	return ulp_swd_parity;
 }
 
-static inline void swdio_set(uint32_t val)
+static void swdptap_seq_out(const uint32_t tms_states, const size_t clock_cycles)
 {
-	if (val) {
-		swdio_high();
-	} else {
-		swdio_low();
+	ulp_swd_direction_is_output = true;
+	ulp_swd_has_parity = false;
+	ulp_swd_value = tms_states;
+	ulp_swd_length = clock_cycles;
+	// TODO: Remove this?
+	while (ulp_swd_length) {
 	}
 }
 
-static inline uint32_t swdio_get(void)
+static void swdptap_seq_out_parity(const uint32_t tms_states, const size_t clock_cycles)
 {
-#if SWDIO_PIN < 32
-	return GPIO.in & (1 << SWDIO_PIN);
-#else
-	return GPIO.in1.data & (1 << (SWDIO_PIN - 32));
-#endif
-}
-
-static inline void swclk_high(void)
-{
-#if SWCLK_PIN < 32
-	GPIO.out_w1ts = (1 << SWCLK_PIN);
-#else
-	GPIO.out1_w1ts.data = (1 << (SWCLK_PIN - 32));
-#endif
-}
-
-static inline void swclk_low(void)
-{
-#if SWCLK_PIN < 32
-	GPIO.out_w1tc = (1 << SWCLK_PIN);
-#else
-	GPIO.out1_w1tc.data = (1 << (SWCLK_PIN - 32));
-#endif
-}
-
-static inline void swdio_mode_float(void)
-{
-	gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, GPIO_MODE_INPUT);
-	// #if CONFIG_TMS_SWDIO_GPIO < 32
-	// 	GPIO.enable_w1tc = (0x1 << CONFIG_TMS_SWDIO_GPIO);
-	// #else
-	// 	GPIO.enable1_w1tc.data = (0x1 << (CONFIG_TMS_SWDIO_GPIO - 32));
-	// #endif
-
-#if CONFIG_TMS_SWDIO_DIR_GPIO < 32
-	GPIO.out_w1ts = (1 << CONFIG_TMS_SWDIO_DIR_GPIO);
-#else
-	GPIO.out1_w1ts.data = (1 << (CONFIG_TMS_SWDIO_DIR_GPIO - 32));
-#endif
-}
-
-static inline void swdio_mode_drive(void)
-{
-#if CONFIG_TMS_SWDIO_DIR_GPIO < 32
-	GPIO.out_w1tc = (1 << CONFIG_TMS_SWDIO_DIR_GPIO);
-#else
-	GPIO.out1_w1tc.data = (1 << (CONFIG_TMS_SWDIO_DIR_GPIO - 32));
-#endif
-
-	// #if CONFIG_TMS_SWDIO_GPIO < 32
-	// 	GPIO.enable_w1ts = (0x1 << CONFIG_TMS_SWDIO_GPIO);
-	// #else
-	// 	GPIO.enable1_w1ts.data = (0x1 << (CONFIG_TMS_SWDIO_GPIO - 32));
-	// #endif
-	gpio_ll_output_enable(GPIO_HAL_GET_HW(GPIO_PORT_0), CONFIG_TMS_SWDIO_GPIO);
-}
-
-static void swdptap_turnaround(int dir)
-{
-	static int olddir = SWDIO_STATUS_FLOAT;
-	register volatile int32_t cnt;
-
-	// Throw in a sleep every now and then, in order to allow
-	// for other tasks to run.
-	static int rest_counter = 0;
-	rest_counter += 1;
-	if (rest_counter > 1000) {
-		rest_counter = 0;
-		vTaskDelay(1);
-	}
-
-	/* Don't turnaround if direction not changing */
-	if (dir == olddir)
-		return;
-	olddir = dir;
-
-#ifdef DEBUG_SWD_BITS
-	DEBUG("%s", dir ? "\n-> " : "\n<- ");
-#endif
-	if (dir == SWDIO_STATUS_FLOAT)
-		swdio_mode_float();
-	swclk_high();
-	for (cnt = swd_delay_cnt; --cnt > 0;)
-		;
-	swclk_low();
-	for (cnt = swd_delay_cnt; --cnt > 0;)
-		;
-	if (dir == SWDIO_STATUS_DRIVE)
-		swdio_mode_drive();
-}
-
-static uint32_t swdptap_seq_in(size_t ticks)
-{
-	uint32_t index = 1;
-	uint32_t ret = 0;
-	int len = ticks;
-	register volatile int32_t cnt;
-	// portENTER_CRITICAL();
-	swdptap_turnaround(SWDIO_STATUS_FLOAT);
-	if (swd_delay_cnt) {
-		while (len--) {
-			int res;
-			res = swdio_get();
-			swclk_high();
-			for (cnt = swd_delay_cnt; --cnt > 0;)
-				;
-			ret |= (res) ? index : 0;
-			index <<= 1;
-			swclk_low();
-			for (cnt = swd_delay_cnt; --cnt > 0;)
-				;
-		}
-	} else {
-		volatile int res;
-		while (len--) {
-			res = swdio_get();
-			swclk_high();
-			ret |= (res) ? index : 0;
-			index <<= 1;
-			swclk_low();
-		}
-	}
-#ifdef DEBUG_SWD_BITS
-	for (int i = 0; i < len; i++)
-		DEBUG("%d", (ret & (1 << i)) ? 1 : 0);
-#endif
-	return ret;
-}
-
-static bool swdptap_seq_in_parity(uint32_t *ret, size_t ticks)
-{
-	uint32_t index = 1;
-	uint32_t res = 0;
-	bool bit;
-	int len = ticks;
-	register volatile int32_t cnt;
-
-	swdptap_turnaround(SWDIO_STATUS_FLOAT);
-	if (swd_delay_cnt) {
-		while (len--) {
-			bit = swdio_get();
-			swclk_high();
-			for (cnt = swd_delay_cnt; --cnt > 0;)
-				;
-			res |= (bit) ? index : 0;
-			index <<= 1;
-			swclk_low();
-			for (cnt = swd_delay_cnt; --cnt > 0;)
-				;
-		}
-	} else {
-		while (len--) {
-			bit = swdio_get();
-			swclk_high();
-			res |= (bit) ? index : 0;
-			index <<= 1;
-			swclk_low();
-		}
-	}
-	int parity = __builtin_popcount(res);
-	bit = swdio_get();
-	swclk_high();
-	for (cnt = swd_delay_cnt; --cnt > 0;)
-		;
-	parity += (bit) ? 1 : 0;
-	swclk_low();
-	for (cnt = swd_delay_cnt; --cnt > 0;)
-		;
-#ifdef DEBUG_SWD_BITS
-	for (int i = 0; i < len; i++)
-		DEBUG("%d", (res & (1 << i)) ? 1 : 0);
-#endif
-	*ret = res;
-	/* Terminate the read cycle now */
-	swdptap_turnaround(SWDIO_STATUS_DRIVE);
-	return (parity & 1);
-}
-
-static void swdptap_seq_out(uint32_t MS, size_t ticks)
-{
-#ifdef DEBUG_SWD_BITS
-	for (int i = 0; i < ticks; i++)
-		DEBUG("%d", (MS & (1 << i)) ? 1 : 0);
-#endif
-	// portENTER_CRITICAL();
-	register volatile int32_t cnt;
-	swdptap_turnaround(SWDIO_STATUS_DRIVE);
-	swdio_set(MS & 1);
-	if (swd_delay_cnt) {
-		while (ticks--) {
-			swclk_high();
-			for (cnt = swd_delay_cnt; --cnt > 0;)
-				;
-			MS >>= 1;
-			swdio_set(MS & 1);
-			swclk_low();
-			for (cnt = swd_delay_cnt; --cnt > 0;)
-				;
-		}
-	} else {
-		while (ticks--) {
-			swclk_high();
-			MS >>= 1;
-			swdio_set(MS & 1);
-			swclk_low();
-		}
+	ulp_swd_parity = __builtin_popcount(tms_states) & 1;
+	ulp_swd_direction_is_output = true;
+	ulp_swd_has_parity = true;
+	ulp_swd_value = tms_states;
+	ulp_swd_length = clock_cycles;
+	// TODO: Remove this?
+	while (ulp_swd_length) {
 	}
 }
-
-static void swdptap_seq_out_parity(uint32_t MS, size_t ticks)
-{
-	int parity = __builtin_popcount(MS);
-#ifdef DEBUG_SWD_BITS
-	for (int i = 0; i < ticks; i++)
-		DEBUG("%d", (MS & (1 << i)) ? 1 : 0);
 #endif
-	register volatile int32_t cnt;
-	swdptap_turnaround(SWDIO_STATUS_DRIVE);
-	swdio_set(MS & 1);
-	MS >>= 1;
-	if (swd_delay_cnt) {
-		while (ticks--) {
-			swclk_high();
-			for (cnt = swd_delay_cnt; --cnt > 0;)
-				;
-			swdio_set(MS & 1);
-			MS >>= 1;
-			swclk_low();
-			for (cnt = swd_delay_cnt; --cnt > 0;)
-				;
-		}
-	} else {
-		while (ticks--) {
-			swclk_high();
-			swdio_set(MS & 1);
-			MS >>= 1;
-			swclk_low();
-		}
-	}
-	gpio_set_val(SWDIO_PORT, SWDIO_PIN, parity & 1);
-	swclk_high();
-	for (cnt = swd_delay_cnt; --cnt > 0;)
-		;
-	swclk_low();
-	for (cnt = swd_delay_cnt; --cnt > 0;)
-		;
+
+void init_ulp_program(void)
+{
+	ulp_riscv_halt();
+
+	extern const uint8_t ulp_main_bin_start[] asm("_binary_ulp_bmp_bin_start");
+	extern const uint8_t ulp_main_bin_end[] asm("_binary_ulp_bmp_bin_end");
+	esp_err_t err = ulp_riscv_load_binary(ulp_main_bin_start, (ulp_main_bin_end - ulp_main_bin_start));
+	ESP_ERROR_CHECK(err);
+
+	/* The first argument is the period index, which is not used by the ULP-RISC-V timer
+     * The second argument is the period in microseconds, which gives a wakeup time period of: 200ms
+     */
+	ulp_set_wakeup_period(0, 20000);
+
+	/* Start the program */
+	err = ulp_riscv_run();
+	ESP_ERROR_CHECK(err);
+}
+static void configure_clock(void)
+{
+	// rtc_clk_8m_enable(true, true);
+	// rtc_clk_slow_src_set(SOC_RTC_SLOW_CLK_SRC_RC_FAST_D256);
 }
 
 int swdptap_init(ADIv5_DP_t *dp)
 {
+#if 0
+	configure_clock();
+	rtc_gpio_init(CONFIG_TMS_SWDIO_GPIO);
+	rtc_gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, RTC_GPIO_MODE_INPUT_OUTPUT);
+	rtc_gpio_pulldown_dis(CONFIG_TMS_SWDIO_GPIO);
+	rtc_gpio_pullup_dis(CONFIG_TMS_SWDIO_GPIO);
+
+	rtc_gpio_init(CONFIG_TMS_SWDIO_DIR_GPIO);
+	rtc_gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, RTC_GPIO_MODE_OUTPUT_ONLY);
+	rtc_gpio_pulldown_dis(CONFIG_TMS_SWDIO_GPIO);
+	rtc_gpio_pullup_dis(CONFIG_TMS_SWDIO_GPIO);
+
+	rtc_gpio_init(CONFIG_TCK_SWCLK_GPIO);
+	rtc_gpio_set_direction(CONFIG_TCK_SWCLK_GPIO, RTC_GPIO_MODE_OUTPUT_ONLY);
+	rtc_gpio_pulldown_dis(CONFIG_TCK_SWCLK_GPIO);
+	rtc_gpio_pullup_dis(CONFIG_TCK_SWCLK_GPIO);
+
+	ulp_swd_has_parity = false;
+	init_ulp_program();
+
+	ESP_LOGI("swd", "Waiting for has_parity to go true...");
+	while (!ulp_swd_has_parity) {
+	}
+	ESP_LOGI("swd", "Parity is 1");
+
 	dp->seq_in = swdptap_seq_in;
 	dp->seq_in_parity = swdptap_seq_in_parity;
 	dp->seq_out = swdptap_seq_out;
 	dp->seq_out_parity = swdptap_seq_out_parity;
-
-	gpio_reset_pin(CONFIG_TDI_GPIO);
-	gpio_reset_pin(CONFIG_TDO_GPIO);
-	gpio_reset_pin(CONFIG_TMS_SWDIO_GPIO);
-	gpio_reset_pin(CONFIG_TCK_SWCLK_GPIO);
-	gpio_reset_pin(CONFIG_TMS_SWDIO_DIR_GPIO);
-
-	gpio_set_direction(CONFIG_TDI_GPIO, GPIO_MODE_OUTPUT);
-	gpio_set_direction(CONFIG_TDO_GPIO, GPIO_MODE_INPUT);
-	gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, GPIO_MODE_OUTPUT);
-	gpio_set_direction(CONFIG_TCK_SWCLK_GPIO, GPIO_MODE_OUTPUT);
-	gpio_set_direction(CONFIG_TMS_SWDIO_DIR_GPIO, GPIO_MODE_OUTPUT);
-	gpio_set_level(CONFIG_TMS_SWDIO_DIR_GPIO, 0);
-
-	// gpio_iomux_in(CONFIG_TMS_SWDIO_DIR_GPIO, PIN_FUNC_GPIO);
-	// gpio_iomux_out(CONFIG_TMS_SWDIO_DIR_GPIO, PIN_FUNC_GPIO, false);
-	// gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[CONFIG_TMS_SWDIO_DIR_GPIO], PIN_FUNC_GPIO);
-
-	// gpio_hal_iomux_func_sel(CONFIG_TCK_SWCLK_GPIO, PIN_FUNC_GPIO);
-	// gpio_iomux_in(CONFIG_TCK_SWCLK_GPIO, 1);
-	// gpio_iomux_out(CONFIG_TCK_SWCLK_GPIO, 1, false);
-
-	// GPIO.pin[CONFIG_TMS_SWDIO_DIR_GPIO].sync1_bypass = 0;
-	// GPIO.pin[CONFIG_TMS_SWDIO_DIR_GPIO].sync2_bypass = 0;
+#endif
 	return 0;
 }
 #endif

--- a/main/gdb_if.c
+++ b/main/gdb_if.c
@@ -219,10 +219,7 @@ static void new_gdb_wifi_instance(int sock)
 	memset(instance, 0, sizeof(*instance));
 	instance->sock = sock;
 
-	// Create the task at the IDLE priority, to allow the idle thread to keep
-	// the watchdog happy. This will get preemptively scheduled at the same
-	// priority as the IDLE task.
-	xTaskCreate(gdb_wifi_task, name, 5500, (void *)instance, tskIDLE_PRIORITY + 1, &instance->pid);
+	xTaskCreate(gdb_wifi_task, name, 12000, (void *)instance, tskIDLE_PRIORITY + 1, &instance->pid);
 }
 
 void gdb_net_task(void *arg)

--- a/main/http.c
+++ b/main/http.c
@@ -61,7 +61,7 @@ static esp_err_t cgi_baud(httpd_req_t *req)
 	}
 
 	uint32_t baud = 0;
-	uart_get_baudrate(0, &baud);
+	uart_get_baudrate(CONFIG_TARGET_UART_IDX, &baud);
 
 	len = snprintf(buff, sizeof(buff), "{\"baudrate\": %lu }", baud);
 	httpd_resp_set_type(req, "text/json");

--- a/main/http.c
+++ b/main/http.c
@@ -120,15 +120,13 @@ static esp_err_t cgi_status_header(httpd_req_t *req)
 {
 	char buffer[256];
 
-	uint32_t esp_debug_baud = 0;
 	uint32_t target_baud = 0;
 	uint32_t swo_baud = 0;
-	uart_get_baudrate(0, &esp_debug_baud);
 	uart_get_baudrate(1, &target_baud);
-	// 	extern int swo_active;
-	// 	if (swo_active) {
-	// 		uart_get_baudrate(2, &baud2);
-	// 	}
+	extern int swo_active;
+	if (swo_active) {
+		uart_get_baudrate(2, &swo_baud);
+	}
 
 	snprintf(buffer, sizeof(buffer),
 		"free_heap: %" PRIu32 "\n"
@@ -137,10 +135,9 @@ static esp_err_t cgi_status_header(httpd_req_t *req)
 	httpd_resp_sendstr_chunk(req, buffer);
 
 	snprintf(buffer, sizeof(buffer),
-		"debug_baud_rate: %" PRIu32 "\n"
 		"target_baud_rate: %" PRIu32 "\n"
 		"swo_baud_rate: %" PRIu32 "\n",
-		esp_debug_baud, target_baud, swo_baud);
+		target_baud, swo_baud);
 	httpd_resp_sendstr_chunk(req, buffer);
 
 	snprintf(buffer, sizeof(buffer), "target voltage: %" PRIu32 " mV\n", adc_read_system_voltage());

--- a/main/include/platform.h
+++ b/main/include/platform.h
@@ -51,29 +51,34 @@ void platform_set_baud(uint32_t baud);
 	do {                                                                                  \
 		/*gpio_ll_output_disable(GPIO_HAL_GET_HW(GPIO_PORT_0), CONFIG_TMS_SWDIO_GPIO); */ \
 		gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, GPIO_MODE_INPUT);                       \
-		gpio_set_level(CONFIG_TMS_SWDIO_DIR_GPIO, 1);                                     \
+		if (CONFIG_TMS_SWDIO_DIR_GPIO >= 0)                                               \
+			gpio_set_level(CONFIG_TMS_SWDIO_DIR_GPIO, 1);                                 \
 	} while (0)
 
 #define SWDIO_MODE_DRIVE()                                                          \
 	do {                                                                            \
-		gpio_set_level(CONFIG_TMS_SWDIO_DIR_GPIO, 0);                               \
+		if (CONFIG_TMS_SWDIO_DIR_GPIO >= 0)                                         \
+			gpio_set_level(CONFIG_TMS_SWDIO_DIR_GPIO, 0);                           \
 		gpio_ll_output_enable(GPIO_HAL_GET_HW(GPIO_PORT_0), CONFIG_TMS_SWDIO_GPIO); \
 	} while (0)
 
-#define TMS_SET_MODE()                                                     \
-	do {                                                                   \
-		gpio_reset_pin(CONFIG_TDI_GPIO);                                   \
-		gpio_reset_pin(CONFIG_TDO_GPIO);                                   \
-		gpio_reset_pin(CONFIG_TMS_SWDIO_GPIO);                             \
-		gpio_reset_pin(CONFIG_TCK_SWCLK_GPIO);                             \
-		gpio_reset_pin(CONFIG_TMS_SWDIO_DIR_GPIO);                         \
-                                                                           \
-		gpio_set_direction(CONFIG_TDI_GPIO, GPIO_MODE_OUTPUT);             \
-		gpio_set_direction(CONFIG_TDO_GPIO, GPIO_MODE_INPUT);              \
-		gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, GPIO_MODE_INPUT_OUTPUT); \
-		gpio_set_direction(CONFIG_TCK_SWCLK_GPIO, GPIO_MODE_OUTPUT);       \
-		gpio_set_direction(CONFIG_TMS_SWDIO_DIR_GPIO, GPIO_MODE_OUTPUT);   \
-		gpio_set_level(CONFIG_TMS_SWDIO_DIR_GPIO, 0);                      \
+#define TMS_SET_MODE()                                                       \
+	do {                                                                     \
+		gpio_reset_pin(CONFIG_TDI_GPIO);                                     \
+		gpio_reset_pin(CONFIG_TDO_GPIO);                                     \
+		gpio_reset_pin(CONFIG_TMS_SWDIO_GPIO);                               \
+		gpio_reset_pin(CONFIG_TCK_SWCLK_GPIO);                               \
+		if (CONFIG_TMS_SWDIO_DIR_GPIO >= 0)                                  \
+			gpio_reset_pin(CONFIG_TMS_SWDIO_DIR_GPIO);                       \
+                                                                             \
+		gpio_set_direction(CONFIG_TDI_GPIO, GPIO_MODE_OUTPUT);               \
+		gpio_set_direction(CONFIG_TDO_GPIO, GPIO_MODE_INPUT);                \
+		gpio_set_direction(CONFIG_TMS_SWDIO_GPIO, GPIO_MODE_INPUT_OUTPUT);   \
+		gpio_set_direction(CONFIG_TCK_SWCLK_GPIO, GPIO_MODE_OUTPUT);         \
+		if (CONFIG_TMS_SWDIO_DIR_GPIO >= 0)                                  \
+			gpio_set_direction(CONFIG_TMS_SWDIO_DIR_GPIO, GPIO_MODE_OUTPUT); \
+		if (CONFIG_TMS_SWDIO_DIR_GPIO >= 0)                                  \
+			gpio_set_level(CONFIG_TMS_SWDIO_DIR_GPIO, 0);                    \
 	} while (0)
 
 #define TMS_PIN CONFIG_TMS_SWDIO_GPIO

--- a/main/platform.c
+++ b/main/platform.c
@@ -105,7 +105,9 @@ void platform_init(void)
 	gpio_reset_pin(CONFIG_TDO_GPIO);
 	gpio_reset_pin(CONFIG_TMS_SWDIO_GPIO);
 	gpio_reset_pin(CONFIG_TCK_SWCLK_GPIO);
+#if CONFIG_TMS_SWDIO_DIR_GPIO >= 0
 	gpio_reset_pin(CONFIG_TMS_SWDIO_DIR_GPIO);
+#endif
 
 	// Reset Button
 	{
@@ -189,6 +191,7 @@ void platform_init(void)
 		gpio_set_level(CONFIG_TDI_GPIO, 1);
 	}
 
+#if CONFIG_TMS_SWDIO_DIR_GPIO >= 0
 	// TMS/SWDIO level shifter direction
 	{
 		const gpio_config_t gpio_conf = {
@@ -201,6 +204,7 @@ void platform_init(void)
 		gpio_config(&gpio_conf);
 		gpio_set_level(CONFIG_TMS_SWDIO_DIR_GPIO, 1);
 	}
+#endif
 }
 
 void platform_buffer_flush(void)


### PR DESCRIPTION
Fix the following issues:

* The UART was incorrect, resulting in a crash when the built-in serial debug UART was disabled
* BMP has increased its stack usage, causing a stack overflow