### PR TITLE
components: update blackmagic to fix opencm3

### DIFF
--- a/main/include/platform.h
+++ b/main/include/platform.h
@@ -36,6 +36,14 @@ void platform_set_baud(uint32_t baud);
 #define SET_IDLE_STATE(state)
 #define SET_ERROR_STATE(state) gpio_set_level(CONFIG_LED_GPIO, !state)
 
+#ifndef NO_LIBOPENCM3
+#define NO_LIBOPENCM3
+#endif
+
+#ifndef PC_HOSTED
+#define PC_HOSTED 0
+#endif
+
 #if 1
 #define ENABLE_DEBUG 1
 #define DEBUG(x, ...)                        \


### PR DESCRIPTION
An upstream change broke opencm3 to the point where it no longer builds.

Signed-off-by: Sean Cross <sean@xobs.io>