### PR TITLE
github: unshallow the blackmagic port to merge history

### DIFF
--- a/.github/workflows/build-nightly-blackmagic.yml
+++ b/.github/workflows/build-nightly-blackmagic.yml
@@ -59,6 +59,7 @@ jobs:
       run: |
         git -C farpatch/components/blackmagic/blackmagic remote add upstream https://github.com/blackmagic-debug/blackmagic.git
         git -C farpatch/components/blackmagic/blackmagic fetch upstream
+        git -C farpatch/components/blackmagic/blackmagic pull --unshallow
         git -C farpatch/components/blackmagic/blackmagic rebase upstream/main
 
     - name: Build project for ESP32


### PR DESCRIPTION
This will allow us to ensure we can merge history. This fixes the nightly build.