### PR TITLE
The allocated stack size of 2048 for xTaskCreate is too small.

### DIFF
--- a/main/uart.c
+++ b/main/uart.c
@@ -288,7 +288,7 @@ void uart_init(void)
 	ESP_LOGI(__func__, "configuring UART%d for target", TARGET_UART_IDX);
 
 	// Start UART tasks
-	xTaskCreate(uart_hw_task, "uart_hw_task", 2048, NULL, 1, NULL);
+	xTaskCreate(uart_hw_task, "uart_hw_task", 3072, NULL, 1, NULL);
 	xTaskCreate(uart_net_task, "uart_net_task", 6 * 1024, NULL, 1, NULL);
 #endif
 }


### PR DESCRIPTION
![image](https://github.com/farpatch/farpatch/assets/7093082/a1d37155-79dd-4bed-a309-cd3be333c4d6)
