### PR TITLE
usb.h: add file to fix nightly build

### DIFF
--- a/components/blackmagic/usb.h
+++ b/components/blackmagic/usb.h
@@ -1,0 +1,11 @@
+#ifndef USB_H__
+#define USB_H__
+
+/* This file is included by `command.c` when TRACESWO is enabled. */
+
+/* This dummy value is only used for printing out a notification message.
+ * The value has no practical use.
+ */
+#define TRACE_ENDPOINT -1
+
+#endif /* !defined USB_H__ */

--- a/main/http.c
+++ b/main/http.c
@@ -377,7 +377,7 @@ static esp_err_t cgi_frog_fs_hook(httpd_req_t *req)
 	// Temporarily reuse the chunk buffer to store the URI,
 	// minus any extraneous bits
 	memset(chunk, 0, sizeof(chunk));
-	strncpy(chunk, req->uri, strlen(req->uri));
+	strncpy(chunk, req->uri, sizeof(chunk));
 	char *param;
 	param = (char *)strstr(chunk, "?");
 	if (param != NULL)

--- a/main/include/platform.h
+++ b/main/include/platform.h
@@ -116,25 +116,25 @@ void platform_set_baud(uint32_t baud);
 /* CONFIG_IDF_TARGET_ESP32C3 */
 
 #elif defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32)
-#define gpio_set(port, pin)                       \
-	do {                                          \
-		if (pin < 0) {                            \
-		} else if (pin < 32) {                    \
-			GPIO.out_w1ts = (1 << (uint32_t)pin); \
-		} else if (pin < 64) {                    \
-			uint32_t p = pin - 32;                \
-			GPIO.out1_w1ts.data = (1 << p);       \
-		}                                         \
+#define gpio_set(port, pin)                              \
+	do {                                                 \
+		if (pin < 0) {                                   \
+		} else if (pin < 32) {                           \
+			GPIO.out_w1ts = (1 << (uint32_t)(pin & 31)); \
+		} else if (pin < 64) {                           \
+			uint32_t p = pin - 32;                       \
+			GPIO.out1_w1ts.data = (1 << p);              \
+		}                                                \
 	} while (0)
-#define gpio_clear(port, pin)                     \
-	do {                                          \
-		if (pin < 0) {                            \
-		} else if (pin < 32) {                    \
-			GPIO.out_w1tc = (1 << (uint32_t)pin); \
-		} else if (pin < 64) {                    \
-			uint32_t p = pin - 32;                \
-			GPIO.out1_w1tc.data = (1 << p);       \
-		}                                         \
+#define gpio_clear(port, pin)                            \
+	do {                                                 \
+		if (pin < 0) {                                   \
+		} else if (pin < 32) {                           \
+			GPIO.out_w1tc = (1 << (uint32_t)(pin & 31)); \
+		} else if (pin < 64) {                           \
+			uint32_t p = pin - 32;                       \
+			GPIO.out1_w1tc.data = (1 << p);              \
+		}                                                \
 	} while (0)
 #define gpio_get(port, pin) ((pin < 0 ? 0 : pin < 32 ? (GPIO.in >> pin) : (GPIO.in1.data >> (pin - 32))) & 0x1)
 /* CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32 */


### PR DESCRIPTION
`command.c` now requires `usb.h` to exist, as well as a dummy `TRACE_ENDPOINT` value for printing.

This value is not used except to print a message.