### PR TITLE
http-api: increase buffer for status page

### DIFF
--- a/main/http_api.c
+++ b/main/http_api.c
@@ -217,7 +217,7 @@ static void append_reset_reason(httpd_req_t *req)
 
 static void append_networking_to_output(httpd_req_t *req)
 {
-	char buffer[256];
+	char buffer[384];
 	esp_netif_ip_info_t ip_info = wilma_get_ip_info();
 	char ip[IP4ADDR_STRLEN_MAX]; /* note: IP4ADDR_STRLEN_MAX is defined in lwip */
 	char gw[IP4ADDR_STRLEN_MAX];


### PR DESCRIPTION
The buffer will be filled with a long SSID or a long hostname.