### PR TITLE
github: replace upload-artifact with v4

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -86,21 +86,21 @@ jobs:
         cp build/ota_data_initial.bin                 ../artifacts/esp32c3/ota_data_initial.bin
 
     - name: Archive firmware build artifacts for ESP32 as a zip
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         name: blackmagic-firmware-esp32.zip
         path: artifacts/esp32/*
         if-no-files-found: error
         
     - name: Archive firmware build artifacts for ESP32S3 as a zip
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         name: blackmagic-firmware-esp32s3.zip
         path: artifacts/esp32s3/*
         if-no-files-found: error
 
     - name: Archive firmware build artifacts for ESP32C3 as a zip
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         name: blackmagic-firmware-esp32c3.zip
         path: artifacts/esp32c3/*


### PR DESCRIPTION
Github has broken v1 and v2. Jump straight to v4 to see if that fixes the build.