### PR TITLE
blackmagic: add new packet buffer function

### DIFF
--- a/components/blackmagic/general.h
+++ b/components/blackmagic/general.h
@@ -22,6 +22,9 @@
 void bmp_core_lock();
 void bmp_core_unlock();
 
+// Ensure BMP uses our buffers for GDB packets
+#define EXTERNAL_PACKET_BUFFER
+
 #ifdef ENABLE_DEBUG
 #include "esp_log.h"
 

--- a/main/gdb_main_farpatch.h
+++ b/main/gdb_main_farpatch.h
@@ -3,6 +3,7 @@
 
 #include <freertos/FreeRTOS.h>
 #include <gdb_main.h>
+#include <gdb_packet.h>
 
 #define EXCEPTION_NETWORK 0x40
 #define EXCEPTION_MUTEX   0x41
@@ -15,7 +16,7 @@ struct gdb_wifi_instance {
 	int sock;
 	uint8_t tx_buf[1028];
 	uint8_t rx_buf[1028];
-	char pbuf[GDB_PACKET_BUFFER_SIZE + 4];
+	struct gdb_packet gdb_packet;
 	uint16_t tx_bufsize;
 	uint16_t rx_bufsize;
 	uint16_t rx_bufpos;

--- a/main/include/platform.h
+++ b/main/include/platform.h
@@ -36,8 +36,10 @@ extern bool debug_bmp;
 void platform_buffer_flush(void);
 void platform_set_baud(uint32_t baud);
 
-#define SET_RUN_STATE(state)
-#define SET_IDLE_STATE(state)
+#define SET_RUN_STATE(state) \
+	do {                     \
+	} while (0)
+#define SET_IDLE_STATE(state)  gpio_set_level(CONFIG_LED4_GPIO, state)
 #define SET_ERROR_STATE(state) gpio_set_level(CONFIG_LED_GPIO, !state)
 
 #ifndef NO_LIBOPENCM3
@@ -78,10 +80,10 @@ void platform_set_baud(uint32_t baud);
 #define TDI_PIN CONFIG_TDI_GPIO
 #define TDO_PIN CONFIG_TDO_GPIO
 
-#define SWDIO_PIN CONFIG_TMS_SWDIO_GPIO
+#define SWDIO_PIN    CONFIG_TMS_SWDIO_GPIO
 #define SWDIO_IN_PIN CONFIG_TMS_SWDIO_GPIO
-#define SWCLK_PIN CONFIG_TCK_SWCLK_GPIO
-#define SRST_PIN  CONFIG_SRST_GPIO
+#define SWCLK_PIN    CONFIG_TCK_SWCLK_GPIO
+#define SRST_PIN     CONFIG_SRST_GPIO
 
 #define SWCLK_PORT 0
 #define SWDIO_PORT 0
@@ -148,14 +150,14 @@ void platform_set_baud(uint32_t baud);
 #define PLATFORM_IDENT CONFIG_IDF_TARGET
 
 #define PLATFORM_HAS_TRACESWO
-#define NUM_TRACE_PACKETS (128) /* This is an 8K buffer */
-#define SWO_ENCODING 3     /* 1 = Manchester, 2 = NRZ / async, 3 = Both */
-#define SWO_ENDPOINT CONFIG_SWO_TCP_PORT /* Dummy value -- not used */
+#define NUM_TRACE_PACKETS (128)               /* This is an 8K buffer */
+#define SWO_ENCODING      3                   /* 1 = Manchester, 2 = NRZ / async, 3 = Both */
+#define SWO_ENDPOINT      CONFIG_SWO_TCP_PORT /* Dummy value -- not used */
 
-#define TARGET_UART UART0
+#define TARGET_UART     UART0
 #define TARGET_UART_IDX 0
-#define SWO_UART UART1
-#define SWO_UART_IDX 1
+#define SWO_UART        UART1
+#define SWO_UART_IDX    1
 
 extern uint32_t target_delay_us;
 


### PR DESCRIPTION
Upstream now requires us to provide a packet buffer in an external function rather than passing it through `gdb_main()`.