### PR TITLE
esp-idf: follow rename of http buffer variables

### DIFF
--- a/main/http.c
+++ b/main/http.c
@@ -687,8 +687,8 @@ httpd_handle_t webserver_start(void)
 	ESP_LOGI(TAG, "Started HTTP server on port: '%d'", config.server_port);
 	ESP_LOGI(TAG, "Max URI handlers: '%d'", config.max_uri_handlers);
 	ESP_LOGI(TAG, "Max Open Sessions: '%d'", config.max_open_sockets);
-	ESP_LOGI(TAG, "Max Header Length: '%d'", HTTPD_MAX_REQ_HDR_LEN);
-	ESP_LOGI(TAG, "Max URI Length: '%d'", HTTPD_MAX_URI_LEN);
+	ESP_LOGI(TAG, "Max Header Length: '%d'", CONFIG_HTTPD_MAX_REQ_HDR_LEN);
+	ESP_LOGI(TAG, "Max URI Length: '%d'", CONFIG_HTTPD_MAX_URI_LEN);
 	ESP_LOGI(TAG, "Max Stack Size: '%d'", config.stack_size);
 
 	return http_daemon;

--- a/main/include/platform.h
+++ b/main/include/platform.h
@@ -39,8 +39,36 @@ void platform_set_baud(uint32_t baud);
 #define SET_RUN_STATE(state) \
 	do {                     \
 	} while (0)
-#define SET_IDLE_STATE(state)  gpio_set_level(CONFIG_LED4_GPIO, state)
-#define SET_ERROR_STATE(state) gpio_set_level(CONFIG_LED_GPIO, !state)
+
+#if CONFIG_LED4_GPIO != -1
+#define SET_IDLE_STATE(state)                         \
+	do {                                              \
+		static int existing_state = false;            \
+		if (existing_state != state) {                \
+			gpio_set_level(CONFIG_LED4_GPIO, !state); \
+		}                                             \
+		existing_state = state;                       \
+	} while (0)
+#else
+#define SET_IDLE_STATE(state) \
+	do {                      \
+	} while (0)
+#endif
+
+#if CONFIG_LED_GPIO != -1
+#define SET_ERROR_STATE(state)                       \
+	do {                                             \
+		static int existing_state = false;           \
+		if (existing_state != state) {               \
+			gpio_set_level(CONFIG_LED_GPIO, !state); \
+		}                                            \
+		existing_state = state;                      \
+	} while (0)
+#else
+#define SET_ERROR_STATE(state) \
+	do {                       \
+	} while (0)
+#endif
 
 #ifndef NO_LIBOPENCM3
 #define NO_LIBOPENCM3


### PR DESCRIPTION
The two http buffer variables were changed in [9846584defbb87ebbf64582ec0ad3bff848ca96f ](https://github.com/espressif/esp-idf/commit/9846584defbb87ebbf64582ec0ad3bff848ca96f) resulting in nightly breakage. Follow this rename.