### PR TITLE
Add esp driver components

### DIFF
--- a/components/blackmagic/CMakeLists.txt
+++ b/components/blackmagic/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 
 idf_component_register(
-    REQUIRES driver esp_driver_gpio esp_partition esp_wifi
+    REQUIRES
+		esp_driver_gpio
+		esp_driver_rmt
+		esp_driver_tsens
+		esp_driver_uart
+		esp_partition
+		esp_wifi
     SRC_DIRS "blackmagic/src/target"
              "blackmagic/src"
              "blackmagic/src/platforms/common"

--- a/main/wilma/wilma.c
+++ b/main/wilma/wilma.c
@@ -839,8 +839,8 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base, int32_t e
 			break;
 		}
 
-		case IP_EVENT_AP_STAIPASSIGNED: {
-			ip_event_ap_staipassigned_t *event = (ip_event_ap_staipassigned_t *)event_data;
+		case IP_EVENT_ASSIGNED_IP_TO_CLIENT: {
+			ip_event_assigned_ip_to_client_t *event = (ip_event_assigned_ip_to_client_t *)event_data;
 			ESP_LOGD(TAG, "station attached to AP with ip:" IPSTR, IP2STR(&event->ip));
 			break;
 		}


### PR DESCRIPTION
Use the new driver components for rmt, uart, and tsense, all of which are now required.

As part of this, fix a deprecation warning on the ip-received event in Wilma.