### PR TITLE
blackmagic: remove upstream stdio_newlib.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # The following lines of boilerplate have to be in your project's
 # CMakeLists in this exact order for cmake to work correctly
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(farpatch)

--- a/components/blackmagic/CMakeLists.txt
+++ b/components/blackmagic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 idf_component_register(
     REQUIRES
@@ -26,15 +26,22 @@ idf_component_register(
                  "blackmagic/src/target/swdptap_generic.c"
                  "blackmagic/src/exception.c"
                  "blackmagic/src/main.c"
-    INCLUDE_DIRS "."
+    INCLUDE_DIRS
+                 "."
                  "blackmagic/src/target"
                  "blackmagic/src"
                  "blackmagic/src/include"
                  "blackmagic/src/platforms/common"
-                 "../../main"
-                 "../../main/include"
-    PRIV_INCLUDE_DIRS "../../main"
-                      "../../main/include"
+    PRIV_INCLUDE_DIRS
+                  "."
+                  "../../main"
+                  "../../main/include"
+    PRIV_REQUIRES main
 )
 add_definitions(-DPROBE_HOST=esp32 -DPC_HOSTED=0 -DNO_LIBOPENCM3=1 -DENABLE_RTT -DDFU_SERIAL_LENGTH=12)
 component_compile_options(-Wno-error=char-subscripts -Wno-char-subscripts)
+
+# Remove this file from blackmagic. If it is present, it will be preferred
+# over the one present in this directory, so we need to manually remove it
+# before building.
+file(REMOVE "blackmagic/src/include/stdio_newlib.h")

--- a/components/blackmagic/stdio_newlib.h
+++ b/components/blackmagic/stdio_newlib.h
@@ -1,0 +1,7 @@
+/* This file is empty. It is included within the Blackmagic
+ * project and overwrites various printf functions with their
+ * integer equivalents.
+ * 
+ * These don't exist on ESP-IDF. Use the full-fat floating
+ * point versions on this target.
+ */


### PR DESCRIPTION
Remove this file as it forces the use of integer versions of stdlib functions that don't exist in esp-idf.

Replace the file locally with a version that does not do any replacing.