### PR TITLE
Fix RTT channels status field

### DIFF
--- a/main/http_api.c
+++ b/main/http_api.c
@@ -246,7 +246,7 @@ static void append_networking_to_output(httpd_req_t *req)
 		"\"ssid\":\"%s\","
 		"\"gdb\": %d,"
 		"\"rtt-tcp\": %d,"
-		"\"rtt-count\": %d,"
+		"\"rtt-channels\": %d,"
 		"\"rtt-udp\": %d,"
 		"\"uart-tcp\": %d,"
 		"\"uart-udp\": %d,"


### PR DESCRIPTION
## Summary

Fix the RTT Channels value not appearing on the dashboard.

The status API returned the field as `rtt-count`, while the frontend expected `rtt-channels`. Rename the API field so the dashboard can locate and display the configured RTT channel count.

## Testing

- Verified the API field matches the frontend dashboard item.
<img width="1298" height="1654" alt="image" src="https://github.com/user-attachments/assets/2af5f534-b42d-4f73-9306-0ceaa8d5c70f" />